### PR TITLE
patch horizon to avoid crashes when creating application credentials

### DIFF
--- a/0001-handle-missing-access_rules.patch
+++ b/0001-handle-missing-access_rules.patch
@@ -1,0 +1,30 @@
+From 8557469a6198edb9194265513fde9a10e0d87d41 Mon Sep 17 00:00:00 2001
+From: Lars Kellogg-Stedman <lars@redhat.com>
+Date: Mon, 2 Nov 2020 13:38:47 -0500
+Subject: [PATCH] handle missing access_rules
+
+we delete the access_rules for keystone_version < 3.13, but we don't
+make the same check in the cleanup method, leading to a KeyError
+exception.
+
+Change-Id: I02e124d90f99d400d8c59bff2c563fdc85e624d4
+---
+ .../dashboards/identity/application_credentials/forms.py        | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/openstack_dashboard/dashboards/identity/application_credentials/forms.py b/openstack_dashboard/dashboards/identity/application_credentials/forms.py
+index c57132b40..c63462d05 100644
+--- a/openstack_dashboard/dashboards/identity/application_credentials/forms.py
++++ b/openstack_dashboard/dashboards/identity/application_credentials/forms.py
+@@ -138,6 +138,8 @@ class CreateApplicationCredentialForm(forms.SelfHandlingForm):
+         except yaml.YAMLError:
+             msg = (_('Access rules must be a valid JSON or YAML list.'))
+             raise forms.ValidationError(msg)
++        except KeyError:
++            pass
+         return cleaned_data
+ 
+ 
+-- 
+2.25.4
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,18 @@ RUN echo "zchunk=False" >> /etc/dnf/dnf.conf && \
 RUN pip3 install -U pip setuptools
 
 # Install Horizon
-ENV PBR_VERSION="16.0.0"
-RUN cd /opt && \
-    git clone --depth=1 https://github.com/openstack/horizon
+ARG HORIZON_VERSION=6199c5fd
+ARG HORIZON_REPO=https://github.com/openstack/horizon
+
+WORKDIR /opt
+RUN git clone ${HORIZON_REPO}
+
+WORKDIR /opt/horizon
+RUN git checkout ${HORIZON_VERSION}
+
+# Patch for https://github.com/CCI-MOC/ops-issues/issues/4
+COPY 0001-handle-missing-access_rules.patch .
+RUN git apply 0001-handle-missing-access_rules.patch
 
 COPY tools/horizon-customizations/logo.svg /opt/horizon/openstack_dashboard/static/dashboard/img/logo.svg
 COPY tools/horizon-customizations/logo.svg /opt/horizon/openstack_dashboard/static/dashboard/img/logo-splash.svg


### PR DESCRIPTION
In order to patch reliably, this pins Horizon at a specific commit.
The patch may need updating if the Horizon revision changes (but
hopefully we'll get the patch upstream before that happens).

Because we're pinning at a specific commit we can't use a shallow
clone anymore, so the image size and build time will go up a bit with
this commit.

closes CCI-MOC/ops-issues#4.
