### PR TITLE
Create and push docker image on new tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,46 @@
+# Builds and pushes a docker image on a new tag.
+#
+# Uses the action:
+# https://github.com/marketplace/actions/build-and-push-docker-images
+name: ci
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Process repository information
+        id: vars
+        run: |
+          echo ::set-output name=image::${GITHUB_REPOSITORY#CCI-MOC/}
+          echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: massopencloud/${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.tag }}
+
+      - name: Update repo description
+        uses: peter-evans/dockerhub-description@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: massopencloud/${{ steps.vars.outputs.image }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Uses GitHub actions to build and push a new docker image to
Docker Hub when a new tag is pushed.